### PR TITLE
Multiple changes:

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ The following code block shows the structure of the configuration file and provi
         // The size of the buffer when calling PutObject.
         "put_object_buffer_size_in_bytes": 8192,
 
-        // The size of the buffer when calling GetObject 
-        "get_buffer_size_in_bytes": 8192 
+        // The size of the buffer when calling GetObject.
+        "get_object_buffer_size_in_bytes": 8192
     },
 
     // Defines how the S3 API server connects to an iRODS server.

--- a/config.json.template
+++ b/config.json.template
@@ -25,8 +25,8 @@
 
         "threads": 10,
 
-        "read_buffer_size_in_bytes": 8192,
-        "write_buffer_size_in_bytes": 8192 
+        "put_object_buffer_size_in_bytes": 8192,
+        "get_object_buffer_size_in_bytes": 8192 
     },
 
     "irods_client": {

--- a/config.json.template
+++ b/config.json.template
@@ -23,7 +23,10 @@
 
         "resource": "demoResc",
 
-        "threads": 10
+        "threads": 10,
+
+        "read_buffer_size_in_bytes": 8192,
+        "write_buffer_size_in_bytes": 8192 
     },
 
     "irods_client": {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(
   PRIVATE
   main.cpp
   connection.cpp
+  configuration.cpp
   persistence_plugin.cpp
   hmac.cpp
   authentication.cpp bucket_plugin.cpp

--- a/src/authentication.cpp
+++ b/src/authentication.cpp
@@ -96,9 +96,9 @@ namespace
             std::transform(
                 url.encoded_params().begin(), url.encoded_params().end(), std::back_inserter(params), [](const auto &a) {
                     if (a.has_value) {
-                        return std::make_pair<std::string, std::string>(uri_encode(a.key), uri_encode(a.value));
+                        return std::pair<std::string, std::string>(a.key, a.value);
                     }
-                    return std::make_pair(uri_encode(a.key), std::string(""));
+                    return std::pair<std::string, std::string>(a.key, std::string(""));
                 });
             std::sort(params.begin(), params.end());
             for (const auto& param : params) {

--- a/src/authentication.cpp
+++ b/src/authentication.cpp
@@ -98,7 +98,7 @@ namespace
                     if (a.has_value) {
                         return std::pair<std::string, std::string>(a.key, a.value);
                     }
-                    return std::pair<std::string, std::string>(a.key, std::string(""));
+                    return std::pair<std::string, std::string>(a.key, "");
                 });
             std::sort(params.begin(), params.end());
             for (const auto& param : params) {

--- a/src/common_routines.hpp
+++ b/src/common_routines.hpp
@@ -1,0 +1,14 @@
+#ifndef IRODS_S3_API_COMMON_ROUTINES_HPP
+#define IRODS_S3_API_COMMON_ROUTINES_HPP
+
+#include <fmt/format.h>
+#include <fmt/chrono.h>
+
+namespace irods::s3::api::common_routines {
+
+    inline std::string convert_time_t_to_str(const time_t& t, const std::string& format) {
+        return fmt::format(fmt::runtime(format), fmt::localtime(t));
+    }
+}
+
+#endif // IRODS_S3_API_COMMON_ROUTINES_HPP

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -1,0 +1,53 @@
+#include <optional>
+#include <nlohmann/json.hpp>
+
+#include "configuration.hpp"
+
+namespace
+{
+    nlohmann::json g_config;
+    std::optional<std::string> resource;
+    std::optional<uint64_t> read_buffer_size_in_bytes;
+    std::optional<uint64_t> write_buffer_size_in_bytes;
+} //namespace
+
+void irods::s3::set_config(const nlohmann::json& _config)
+{
+    g_config = _config;
+}
+
+nlohmann::json& irods::s3::get_config()
+{
+    return g_config;
+}
+
+uint64_t irods::s3::get_read_buffer_size_in_bytes()
+{
+    if (!read_buffer_size_in_bytes.has_value()) {
+        read_buffer_size_in_bytes = g_config.value(
+                nlohmann::json::json_pointer{"/s3_server/read_buffer_size_in_bytes"}, 8192);
+    }
+    return read_buffer_size_in_bytes.value();
+}
+
+uint64_t irods::s3::get_write_buffer_size_in_bytes()
+{
+    if (!write_buffer_size_in_bytes.has_value()) {
+        write_buffer_size_in_bytes = g_config.value(
+                nlohmann::json::json_pointer{"/s3_server/write_buffer_size_in_bytes"}, 8192);
+    }
+    return write_buffer_size_in_bytes.value();
+}
+
+void irods::s3::set_resource(const std::string_view& resc)
+{
+    resource = resc;
+}
+
+std::string irods::s3::get_resource()
+{
+    if (!resource.has_value()) {
+        resource = g_config.value(nlohmann::json::json_pointer{"/resource"}, std::string{});
+    }
+    return resource.value();
+}

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -7,8 +7,8 @@ namespace
 {
     nlohmann::json g_config;
     std::optional<std::string> resource;
-    std::optional<uint64_t> read_buffer_size_in_bytes;
-    std::optional<uint64_t> write_buffer_size_in_bytes;
+    std::optional<uint64_t> put_object_buffer_size_in_bytes;
+    std::optional<uint64_t> get_object_buffer_size_in_bytes;
 } //namespace
 
 void irods::s3::set_config(const nlohmann::json& _config)
@@ -21,22 +21,22 @@ nlohmann::json& irods::s3::get_config()
     return g_config;
 }
 
-uint64_t irods::s3::get_read_buffer_size_in_bytes()
+uint64_t irods::s3::get_put_object_buffer_size_in_bytes()
 {
-    if (!read_buffer_size_in_bytes.has_value()) {
-        read_buffer_size_in_bytes = g_config.value(
-                nlohmann::json::json_pointer{"/s3_server/read_buffer_size_in_bytes"}, 8192);
+    if (!put_object_buffer_size_in_bytes.has_value()) {
+        put_object_buffer_size_in_bytes = g_config.value(
+                nlohmann::json::json_pointer{"/s3_server/put_object_buffer_size_in_bytes"}, 8192);
     }
-    return read_buffer_size_in_bytes.value();
+    return put_object_buffer_size_in_bytes.value();
 }
 
-uint64_t irods::s3::get_write_buffer_size_in_bytes()
+uint64_t irods::s3::get_get_object_buffer_size_in_bytes()
 {
-    if (!write_buffer_size_in_bytes.has_value()) {
-        write_buffer_size_in_bytes = g_config.value(
-                nlohmann::json::json_pointer{"/s3_server/write_buffer_size_in_bytes"}, 8192);
+    if (!get_object_buffer_size_in_bytes.has_value()) {
+        get_object_buffer_size_in_bytes = g_config.value(
+                nlohmann::json::json_pointer{"/s3_server/get_object_buffer_size_in_bytes"}, 8192);
     }
-    return write_buffer_size_in_bytes.value();
+    return get_object_buffer_size_in_bytes.value();
 }
 
 void irods::s3::set_resource(const std::string_view& resc)

--- a/src/configuration.hpp
+++ b/src/configuration.hpp
@@ -1,0 +1,19 @@
+#ifndef IRODS_S3_API_CONFIGURATION_HPP
+#define IRODS_S3_API_CONFIGURATION_HPP
+
+#include <nlohmann/json.hpp>
+
+namespace irods::s3
+{
+    void set_config(const nlohmann::json& _config);
+    nlohmann::json& get_config();
+
+    void set_resource(const std::string_view&);
+    std::string get_resource();
+
+    uint64_t get_read_buffer_size_in_bytes();
+    uint64_t get_write_buffer_size_in_bytes();
+
+} //namespace irods::s3
+
+#endif //IRODS_S3_API_CONFIGURATION_HPP

--- a/src/configuration.hpp
+++ b/src/configuration.hpp
@@ -11,8 +11,8 @@ namespace irods::s3
     void set_resource(const std::string_view&);
     std::string get_resource();
 
-    uint64_t get_read_buffer_size_in_bytes();
-    uint64_t get_write_buffer_size_in_bytes();
+    uint64_t get_put_object_buffer_size_in_bytes();
+    uint64_t get_get_object_buffer_size_in_bytes();
 
 } //namespace irods::s3
 

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -63,7 +63,6 @@ std::string irods::s3::get_resource()
 
 uint64_t irods::s3::get_read_buffer_size_in_bytes()
 {
-    //port = s3_server.value("port", 8080);
     if (!read_buffer_size_in_bytes.has_value()) {
         read_buffer_size_in_bytes = g_config.value(
                 nlohmann::json::json_pointer{"/s3_server/read_buffer_size_in_bytes"}, 8192);

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -8,6 +8,8 @@ namespace
     nlohmann::json g_config;
 
     std::optional<std::string> resource;
+    std::optional<uint64_t> read_buffer_size_in_bytes;
+    std::optional<uint64_t> write_buffer_size_in_bytes;
 } //namespace
 
 std::unique_ptr<rcComm_t, irods::s3::__detail::rcComm_Deleter> irods::s3::get_connection()
@@ -57,4 +59,23 @@ std::string irods::s3::get_resource()
         resource = g_config.value(nlohmann::json::json_pointer{"/resource"}, std::string{});
     }
     return resource.value();
+}
+
+uint64_t irods::s3::get_read_buffer_size_in_bytes()
+{
+    //port = s3_server.value("port", 8080);
+    if (!read_buffer_size_in_bytes.has_value()) {
+        read_buffer_size_in_bytes = g_config.value(
+                nlohmann::json::json_pointer{"/s3_server/read_buffer_size_in_bytes"}, 8192);
+    }
+    return read_buffer_size_in_bytes.value();
+}
+
+uint64_t irods::s3::get_write_buffer_size_in_bytes()
+{
+    if (!write_buffer_size_in_bytes.has_value()) {
+        write_buffer_size_in_bytes = g_config.value(
+                nlohmann::json::json_pointer{"/s3_server/write_buffer_size_in_bytes"}, 8192);
+    }
+    return write_buffer_size_in_bytes.value();
 }

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1,16 +1,8 @@
 #include "connection.hpp"
+#include "configuration.hpp"
 
 #include <irods/rcConnect.h>
 #include <optional>
-
-namespace
-{
-    nlohmann::json g_config;
-
-    std::optional<std::string> resource;
-    std::optional<uint64_t> read_buffer_size_in_bytes;
-    std::optional<uint64_t> write_buffer_size_in_bytes;
-} //namespace
 
 std::unique_ptr<rcComm_t, irods::s3::__detail::rcComm_Deleter> irods::s3::get_connection()
 {
@@ -19,11 +11,11 @@ std::unique_ptr<rcComm_t, irods::s3::__detail::rcComm_Deleter> irods::s3::get_co
 
     using json_ptr = nlohmann::json::json_pointer;
 
-    const auto& host = g_config.at(json_ptr{"/irods_client/host"}).get_ref<const std::string&>();
-    const auto  port = g_config.at(json_ptr{"/irods_client/port"}).get<int>();
-    const auto& zone = g_config.at(json_ptr{"/irods_client/zone"}).get_ref<const std::string&>();
-    const auto& username = g_config.at(json_ptr{"/irods_client/rodsadmin/username"}).get_ref<const std::string&>();
-    const auto& password = g_config.at(json_ptr{"/irods_client/rodsadmin/password"}).get_ref<const std::string&>();
+    const auto& host = get_config().at(json_ptr{"/irods_client/host"}).get_ref<const std::string&>();
+    const auto  port = get_config().at(json_ptr{"/irods_client/port"}).get<int>();
+    const auto& zone = get_config().at(json_ptr{"/irods_client/zone"}).get_ref<const std::string&>();
+    const auto& username = get_config().at(json_ptr{"/irods_client/rodsadmin/username"}).get_ref<const std::string&>();
+    const auto& password = get_config().at(json_ptr{"/irods_client/rodsadmin/password"}).get_ref<const std::string&>();
 
     rErrMsg_t err{};
     result.reset(rcConnect(host.c_str(), port, username.c_str(), zone.c_str(), 0, &err));
@@ -41,40 +33,4 @@ std::unique_ptr<rcComm_t, irods::s3::__detail::rcComm_Deleter> irods::s3::get_co
     }
 
     return result;
-}
-
-void irods::s3::set_config(const nlohmann::json& _config)
-{
-    g_config = _config;
-}
-
-void irods::s3::set_resource(const std::string_view& resc)
-{
-    resource = resc;
-}
-
-std::string irods::s3::get_resource()
-{
-    if (!resource.has_value()) {
-        resource = g_config.value(nlohmann::json::json_pointer{"/resource"}, std::string{});
-    }
-    return resource.value();
-}
-
-uint64_t irods::s3::get_read_buffer_size_in_bytes()
-{
-    if (!read_buffer_size_in_bytes.has_value()) {
-        read_buffer_size_in_bytes = g_config.value(
-                nlohmann::json::json_pointer{"/s3_server/read_buffer_size_in_bytes"}, 8192);
-    }
-    return read_buffer_size_in_bytes.value();
-}
-
-uint64_t irods::s3::get_write_buffer_size_in_bytes()
-{
-    if (!write_buffer_size_in_bytes.has_value()) {
-        write_buffer_size_in_bytes = g_config.value(
-                nlohmann::json::json_pointer{"/s3_server/write_buffer_size_in_bytes"}, 8192);
-    }
-    return write_buffer_size_in_bytes.value();
 }

--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -29,14 +29,7 @@ namespace irods::s3
 
     std::unique_ptr<rcComm_t, __detail::rcComm_Deleter> get_connection();
 
-    void set_config(const nlohmann::json& _config);
 
-    void set_resource(const std::string_view&);
-
-    std::string get_resource();
-
-    uint64_t get_read_buffer_size_in_bytes();
-    uint64_t get_write_buffer_size_in_bytes();
 
 } //namespace irods::s3
 #endif // IRODS_S3_API_CONNECTION_HPP

--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -34,5 +34,9 @@ namespace irods::s3
     void set_resource(const std::string_view&);
 
     std::string get_resource();
+
+    uint64_t get_read_buffer_size_in_bytes();
+    uint64_t get_write_buffer_size_in_bytes();
+
 } //namespace irods::s3
 #endif // IRODS_S3_API_CONNECTION_HPP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,6 +44,10 @@ asio::awaitable<void> handle_request(asio::ip::tcp::socket socket)
 {
     beast::http::parser<true, beast::http::buffer_body> parser;
 
+    // 5 GB is the largest single part size allowed in S3.
+    // See https://aws.amazon.com/s3/faqs/.
+    parser.body_limit(5ULL * 1024 * 1024 * 1024);
+
     std::string buf_back;
     auto buffer = beast::flat_buffer();
     boost::system::error_code ec;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,6 +34,7 @@
 #include <irods/rodsGenQuery.h>
 #include <memory>
 #include <string_view>
+#include <curl/curl.h>
 
 namespace asio = boost::asio;
 namespace this_coro = boost::asio::this_coro;
@@ -62,7 +63,7 @@ asio::awaitable<void> handle_request(asio::ip::tcp::socket socket)
     url2.set_path(parser.get().target().substr(0, parser.get().target().find("?")));
     url2.set_scheme("http");
     if (parser.get().target().find('?') != std::string::npos) {
-        url2.set_query(parser.get().target().substr(parser.get().target().find("?") + 1));
+        url2.set_encoded_query(parser.get().target().substr(parser.get().target().find("?") + 1));
     }
 
     boost::urls::url_view url = url2;
@@ -177,7 +178,7 @@ asio::awaitable<void> listener(unsigned short port)
     for (;;) {
         asio::ip::tcp::socket socket = co_await acceptor.async_accept(boost::asio::use_awaitable);
         asio::co_spawn(executor, handle_request(std::move(socket)), asio::detached);
-        std::cout << "Accepted?" << std::endl;
+        std::cout << std::flush;
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,8 @@
 
 #include "boost/url/url.hpp"
 #include "boost/url/url_view.hpp"
-#include "./connection.hpp"
+#include "connection.hpp"
+#include "configuration.hpp"
 #include "plugin.hpp"
 #include "s3/s3_api.hpp"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,9 +93,13 @@ asio::awaitable<void> handle_request(asio::ip::tcp::socket socket)
                 }
             }
             else {
-                // GetObject
-
-                if (url.params().find("location") != url.params().end() && url.segments().size() > 1) {
+                if (parser.get().target() == "/") {
+                    // This is a ListBucket
+                    std::cout << "ListBucket detected" << std::endl;
+                    co_await irods::s3::actions::handle_listbuckets(socket, parser, url);
+                    co_return;
+                }
+                else if (url.params().find("location") != url.params().end() && url.segments().size() > 1) {
                     // This is GetBucketLocation
                     std::cout << "GetBucketLocation detected" << std::endl;
                     beast::http::response<beast::http::string_body> resp;

--- a/src/persistence_plugin.cpp
+++ b/src/persistence_plugin.cpp
@@ -67,6 +67,8 @@ namespace irods::s3
         const std::string_view& path,
         const std::vector<std::string>& part_ids)
     {
+        // TODO
+        return false;
     }
 
     /// Abort a multipart upload, deleting all partial uploads associated with it.
@@ -74,6 +76,8 @@ namespace irods::s3
     /// \param path The path of the upload.
     bool abort_multipart_upload(rcComm_t* connection, const std::string_view& path)
     {
+        // TODO
+        return false;
     }
 
     std::optional<std::string>
@@ -107,5 +111,8 @@ namespace irods::s3
 
     std::vector<std::string> list_multipart_uploads(rcComm_t* connection)
     {
+        // TODO
+        std::vector<std::string> v;
+        return v;
     }
 } //namespace irods::s3

--- a/src/s3/CMakeLists.txt
+++ b/src/s3/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(
   irods_s3_bridge
   PRIVATE
   listobjects.cpp
+  listbuckets.cpp
   getobject.cpp
   putobject.cpp
   deleteobject.cpp

--- a/src/s3/getobject.cpp
+++ b/src/s3/getobject.cpp
@@ -31,6 +31,8 @@
 #include <irods/rodsErrorTable.h>
 
 #include <boost/stacktrace.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
 
 namespace asio = boost::asio;
 namespace beast = boost::beast;
@@ -66,6 +68,50 @@ asio::awaitable<void> irods::s3::actions::handle_getobject(
     }
     std::cout << "Requested " << path << std::endl;
 
+    // read the range header if it exists
+    // Note:  We are only implementing range headers in the format range: bytes=<start>-[end]
+    std::size_t range_start = 0;
+    std::size_t range_end = 0;
+    auto range_header = parser.get().find("range");
+    if (range_header != parser.get().end()) {
+        if (range_header->value().starts_with("bytes=")) {
+            std::string range = range_header->value().substr(6);
+
+            std::vector<std::string> range_parts;
+            boost::split(range_parts, range, boost::is_any_of("-"));
+
+            if (range_parts.size() != 2) {
+                std::cerr<< "The provided range format has not been implemented." << std::endl;
+                beast::http::response<beast::http::empty_body> response;
+                response.result(beast::http::status::not_implemented);
+                beast::http::write(socket, response);
+                co_return;
+            }
+
+            try {
+                range_start = boost::lexical_cast<std::size_t>(range_parts[0]);
+                if (!range_parts[1].empty()) {
+                    range_end = boost::lexical_cast<std::size_t>(range_parts[1]);
+                }
+            }
+            catch (const boost::bad_lexical_cast&) {
+                std::cerr<< "Could not cast the start or end range to a size_t." << std::endl;
+                beast::http::response<beast::http::empty_body> response;
+                response.result(beast::http::status::not_implemented);
+                beast::http::write(socket, response);
+                co_return;
+            }
+
+        }
+        else {
+            std::cerr<< "The provided range format has not been implemented - does not begin with \"bytes=\"." << std::endl;
+            beast::http::response<beast::http::empty_body> response;
+            response.result(beast::http::status::not_implemented);
+            beast::http::write(socket, response);
+            co_return;
+        }
+    } 
+
     try {
         if (fs::client::exists(*thing, path)) {
             std::cout << "Trying to write file" << std::endl;
@@ -76,8 +122,14 @@ asio::awaitable<void> irods::s3::actions::handle_getobject(
             std::cout << "write buffer size = " << write_buffer_size << std::endl;
             std::vector<char> buf_vector(write_buffer_size);
 
+            auto file_size = irods::experimental::filesystem::client::data_object_size(*thing, path);
+            if (range_end == 0 || range_end > file_size - 1) {
+                range_end = file_size - 1;
+            }
+            auto content_length = range_end - range_start + 1;  // ranges are inclusive
+
             std::string length_field =
-                std::to_string(irods::experimental::filesystem::client::data_object_size(*thing, path));
+                std::to_string(content_length);
             response.insert(beast::http::field::content_length, length_field);
             auto md5 = irods::experimental::filesystem::client::data_object_checksum(*thing, path);
             response.insert("Content-MD5", md5);
@@ -86,6 +138,10 @@ asio::awaitable<void> irods::s3::actions::handle_getobject(
             irods::experimental::io::client::default_transport xtrans{*thing};
             irods::experimental::io::idstream d{
                 xtrans, path, irods::experimental::io::root_resource_name{irods::s3::get_resource()}};
+
+            // seek to the start range
+            d.seekg(range_start);
+            size_t offset = range_start;
 
             if (d.fail() || d.bad()) {
                 std::cout << "Fail/badbit set" << std::endl;
@@ -98,8 +154,18 @@ asio::awaitable<void> irods::s3::actions::handle_getobject(
             std::streampos current, size;
             while (d.good()) {
                 response.result(beast::http::status::ok);
-                d.read(buf_vector.data(), write_buffer_size);
+
+                // Determine the length we need to read which is the smaller
+                // of the write_buffer_size or the bytes to the end of the range.
+                // Note that ranges are inclusive which is why the +1's exist. 
+                std::size_t read_length
+                    = write_buffer_size < range_end + 1 - offset 
+                    ? write_buffer_size 
+                    : range_end + 1 - offset;
+
+                d.read(buf_vector.data(), read_length);
                 current = d.gcount();
+                offset += current;
                 size += current;
                 response.body().data = buf_vector.data();
                 response.body().size = current;
@@ -112,13 +178,19 @@ asio::awaitable<void> irods::s3::actions::handle_getobject(
                 }
                 catch (boost::system::system_error& e) {
                     if (e.code() != beast::http::error::need_buffer) {
-                        std::cout << "Not a good error!" << std::endl;
+                        std::cout << "System error when writing bytes to socket during GetObject - "
+                            << e.code().message() << "[" << e.code() << "]" << std::endl;
                         throw e;
                     }
                     else {
                         // It would be nice if we could figure out something a bit more
                         // semantic than catching an exception
                     }
+                }
+
+                // If we have now read beyond the range_end then we are done.  Break out.
+                if (offset > range_end) {
+                    break;
                 }
             }
             response.body().size = d.gcount();

--- a/src/s3/getobject.cpp
+++ b/src/s3/getobject.cpp
@@ -118,7 +118,7 @@ asio::awaitable<void> irods::s3::actions::handle_getobject(
             beast::http::response<beast::http::buffer_body> response;
             beast::http::response_serializer<beast::http::buffer_body> serializer{response};
 
-            uint64_t write_buffer_size = irods::s3::get_write_buffer_size_in_bytes();
+            uint64_t write_buffer_size = irods::s3::get_get_object_buffer_size_in_bytes();
             std::cout << "write buffer size = " << write_buffer_size << std::endl;
             std::vector<char> buf_vector(write_buffer_size);
 

--- a/src/s3/getobject.cpp
+++ b/src/s3/getobject.cpp
@@ -117,7 +117,6 @@ asio::awaitable<void> irods::s3::actions::handle_getobject(
                     else {
                         // It would be nice if we could figure out something a bit more
                         // semantic than catching an exception
-                        //std::cout << "Good error!" << std::endl;
                     }
                 }
             }

--- a/src/s3/getobject.cpp
+++ b/src/s3/getobject.cpp
@@ -1,6 +1,7 @@
 #include "s3_api.hpp"
 
 #include "../connection.hpp"
+#include "../configuration.hpp"
 #include "../bucket.hpp"
 #include "../authentication.hpp"
 

--- a/src/s3/getobject.cpp
+++ b/src/s3/getobject.cpp
@@ -99,7 +99,6 @@ asio::awaitable<void> irods::s3::actions::handle_getobject(
                 size += current;
                 response.body().data = buffer_backing;
                 response.body().size = current;
-                std::cout << "Wrote " << current << " bytes" << std::endl;
                 if (d.bad()) {
                     std::cerr << "Weird error?" << std::endl;
                     exit(12);
@@ -115,14 +114,13 @@ asio::awaitable<void> irods::s3::actions::handle_getobject(
                     else {
                         // It would be nice if we could figure out something a bit more
                         // semantic than catching an exception
-                        std::cout << "Good error!" << std::endl;
+                        //std::cout << "Good error!" << std::endl;
                     }
                 }
             }
             response.body().size = d.gcount();
             response.body().more = false;
             beast::http::write(socket, serializer);
-            std::cout << "Wrote " << size << " bytes total" << std::endl;
         }
         else {
             beast::http::response<beast::http::empty_body> response;

--- a/src/s3/listbuckets.cpp
+++ b/src/s3/listbuckets.cpp
@@ -1,0 +1,99 @@
+#include "../types.hpp"
+#include "s3_api.hpp"
+#include "../bucket.hpp"
+#include "../connection.hpp"
+#include "../authentication.hpp"
+#include "../common_routines.hpp"
+#include "../configuration.hpp"
+
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/this_coro.hpp>
+#include <experimental/coroutine>
+#include <boost/beast.hpp>
+
+#include <boost/asio.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
+#include <boost/url.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include <irods/filesystem.hpp>
+#include <irods/query_builder.hpp>
+
+#include <iostream>
+#include <unordered_set>
+#include <chrono>
+
+#include <fmt/format.h>
+
+namespace asio = boost::asio;
+namespace beast = boost::beast;
+
+static const std::string date_format{"{:%Y-%m-%dT%H:%M:%S+00:00}"};
+
+asio::awaitable<void> irods::s3::actions::handle_listbuckets(
+    asio::ip::tcp::socket& socket,
+    static_buffer_request_parser& parser,
+    const boost::urls::url_view& url)
+{
+    using namespace boost::property_tree;
+
+    auto rcComm_t_ptr = irods::s3::get_connection();
+
+    if (!irods::s3::authentication::authenticates(*rcComm_t_ptr, parser, url)) {
+        beast::http::response<beast::http::empty_body> response;
+        response.result(beast::http::status::forbidden);
+        beast::http::write(socket, response);
+        co_return;
+    }
+
+    boost::property_tree::ptree document;
+    document.add("ListAllMyBucketsResult", "");
+    document.add("ListAllMyBucketsResult.Buckets", "");
+
+    // get the buckets from the configuration
+    const auto bucket_list  = get_config().at(nlohmann::json::json_pointer{"/s3_server/plugins/static_bucket_resolver/mappings"});
+    for (const auto& [bucket, collection] : bucket_list.items()) {
+
+        // Get the creation time for the collection
+        bool found = false;
+        std::string query;
+        std::time_t create_collection_epoch_time = 0;
+
+        query = fmt::format(
+                "select COLL_CREATE_TIME where COLL_NAME = '{}'",
+                collection.get_ref<const std::string&>());
+
+        std::cout << "query: " << query << std::endl;
+
+        for (auto&& row : irods::query<RcComm>(rcComm_t_ptr.get(), query)) {
+            found = true;
+            create_collection_epoch_time = boost::lexical_cast<std::time_t>(row[0]);
+            break;
+        }
+
+        // If creation time not found, user does not have access to the collection the bucket
+        // maps to.  Do not add this bucket to the list.
+        if (found) {
+             std::string create_collection_epoch_time_str = irods::s3::api::common_routines::convert_time_t_to_str(create_collection_epoch_time, date_format);
+
+             ptree object;
+             object.put("CreationDate", create_collection_epoch_time_str);
+             object.put("Name", bucket);
+             document.add_child("ListAllMyBucketsResult.Buckets.Bucket", object);
+        }
+    }
+    document.add("ListAllMyBucketsResult.Owner", "");
+
+    std::stringstream s;
+    boost::property_tree::xml_parser::xml_writer_settings<std::string> settings;
+    settings.indent_char = ' ';
+    settings.indent_count = 4;
+    boost::property_tree::write_xml(s, document, settings);
+    beast::http::response<beast::http::string_body> response;
+    response.body() = s.str();
+    std::cout << s.str();
+
+    beast::http::write(socket, response);
+    co_return;
+}

--- a/src/s3/listobjects.cpp
+++ b/src/s3/listobjects.cpp
@@ -3,6 +3,7 @@
 #include "../bucket.hpp"
 #include "../connection.hpp"
 #include "../authentication.hpp"
+#include "../common_routines.hpp"
 
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/this_coro.hpp>
@@ -13,17 +14,21 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/url.hpp>
+#include <boost/lexical_cast.hpp>
 
 #include <irods/filesystem.hpp>
 #include <irods/query_builder.hpp>
 
 #include <iostream>
 #include <unordered_set>
+#include <chrono>
 
 #include <fmt/format.h>
 
 namespace asio = boost::asio;
 namespace beast = boost::beast;
+
+static const std::string date_format{"{:%Y-%m-%dT%H:%M:%S.000Z}"};
 
 asio::awaitable<void> irods::s3::actions::handle_listobjects_v2(
     asio::ip::tcp::socket& socket,
@@ -32,9 +37,9 @@ asio::awaitable<void> irods::s3::actions::handle_listobjects_v2(
 {
     using namespace boost::property_tree;
 
-    auto thing = irods::s3::get_connection();
+    auto rcComm_t_ptr = irods::s3::get_connection();
 
-    if (!irods::s3::authentication::authenticates(*thing, parser, url)) {
+    if (!irods::s3::authentication::authenticates(*rcComm_t_ptr, parser, url)) {
         beast::http::response<beast::http::empty_body> response;
         response.result(beast::http::status::forbidden);
         beast::http::write(socket, response);
@@ -42,8 +47,9 @@ asio::awaitable<void> irods::s3::actions::handle_listobjects_v2(
     }
 
     irods::experimental::filesystem::path bucket_base;
-    if (auto bucket = irods::s3::resolve_bucket(*thing, url.segments()); bucket.has_value()) {
+    if (auto bucket = irods::s3::resolve_bucket(*rcComm_t_ptr, url.segments()); bucket.has_value()) {
         bucket_base = bucket.value();
+        std::cout << "bucket_base: " << bucket_base.c_str() << std::endl;
     }
     else {
         beast::http::response<beast::http::empty_body> response;
@@ -56,90 +62,206 @@ asio::awaitable<void> irods::s3::actions::handle_listobjects_v2(
     std::cout << __func__ << ": resolved path [" << resolved_path << "]\n";
     boost::property_tree::ptree document;
 
-    std::string filename_prefix = "%";
-
+    irods::experimental::filesystem::path the_prefix; 
     if (const auto prefix = url.params().find("prefix"); prefix != url.params().end()) {
-        filename_prefix = (*prefix).value + "%";
+        the_prefix = (*prefix).value;
     }
 
+    // For recursive searches, no delimiter is passed in.  In that case only return all data objects
+    // which have the prefix. 
+    // TODO:  We might not be able to support delimiters that are not "/". 
+    bool delimiter_in_request = false;
+    if (const auto prefix = url.params().find("delimiter"); prefix != url.params().end()) {
+        delimiter_in_request = true;
+    }
+
+    auto full_path = resolved_path / the_prefix;
+    
     std::string query;
-    if (resolved_path != bucket_base) {
-        query = fmt::format(
-            "select COLL_NAME,DATA_NAME,DATA_OWNER_NAME,DATA_SIZE where COLL_NAME like '{}%' AND DATA_NAME like "
-            "'{}'",
-            resolved_path.c_str(),
-            filename_prefix,
-            resolved_path.parent_path().c_str(),
-            filename_prefix);
-    }
-    else {
-        query = fmt::format(
-            "select COLL_NAME,DATA_NAME,DATA_OWNER_NAME,DATA_SIZE where COLL_NAME like '{}' AND DATA_NAME LIKE '{}'",
-            resolved_path.parent_path().c_str(),
-            filename_prefix);
-    }
-    std::cout << query << std::endl;
 
-    auto contents = document.add("ListBucketResult", "");
+    document.add("ListBucketResult", "");
+    document.add("ListBucketResult.Name", bucket_base.c_str());
+    document.add("ListBucketResult.Prefix", the_prefix.c_str());
+    document.add("ListBucketResult.Marker", "");
+    document.add("ListBucketResult.IsTruncated", "false");
 
     bool found_objects = false;
-    std::unordered_set<std::string> seen_keys;
 
-    for (auto&& i : irods::query<RcComm>(thing.get(), query)) {
-        //        if (!found_objects) {
-        //            std::cout << "Found an object! It has " << i.size()<<" fields" << std::endl;
-        //        }
-        found_objects = true;
-        ptree object;
-        //        std::cout<< "Adding entry to property tree!"<<std::endl;
-        // This used to always use base_length as the offset, but as it turns out, I don't think data_name
-        // actually contains the full path, which is a funny thing to run into
-        object.put("Key", (i[0].size() > base_length ? i[0].substr(base_length) : "") + i[1]);
-        //        std::cout<<"Added key"<<std::endl;
-        object.put("Etag", i[0] + i[1]);
-        //        std::cout<<"Added etag"<<std::endl;
-        object.put("Owner", i[2]);
-        //        std::cout<<"Added owner"<<std::endl;
-        object.put("Size", atoi(i[3].c_str()));
-        //        std::cout<<"Added size"<<std::endl;
-        // add_child always creates a new node, put_child would replace the previous one.
-        //        std::cout<<"Adding it to the document"<<std::endl;
-        document.add_child("ListBucketResult.Contents", object);
-    }
-    // Required for genquery limitations :p
-    query = fmt::format(
-        "select COLL_NAME,DATA_NAME,DATA_OWNER_NAME,DATA_SIZE where COLL_NAME like '{}/{}'",
-        resolved_path.parent_path().c_str(),
-        filename_prefix);
-    std::cout << query << std::endl;
-    for (auto&& i : irods::query<RcComm>(thing.get(), query)) {
-        found_objects = true;
-        ptree object;
-        object.put("Key", i[0].substr(base_length) + "/" + i[1]);
-        object.put("Etag", i[0] + "/" + i[1]);
-        object.put("Owner", i[2]);
-        object.put("Size", atoi(i[3].c_str()));
-        document.add_child("ListBucketResult.Contents", object);
+    if (delimiter_in_request) {
+
+        if (full_path.object_name().empty()) {
+            // Path ends in a slash, this is an exact collection match
+            // and all objects in that collection
+            
+            // Get exact collections underneath this collection 
+            query = fmt::format(
+                "select COLL_NAME where COLL_NAME like '{}/%' and COLL_NAME not like '{}/%/%'",
+                full_path.parent_path().c_str(),
+                full_path.parent_path().c_str());
+            std::cout << query << std::endl;
+            for (auto&& row : irods::query<RcComm>(rcComm_t_ptr.get(), query)) {
+                found_objects = true;
+                ptree object;
+                std::string key = (row[0].size() > base_length ? row[0].substr(base_length) : "");
+                if (key.starts_with("/")) {
+                    key = key.substr(1);
+                }
+                key += "/";
+                object.put("Prefix", key);
+                document.add_child("ListBucketResult.CommonPrefixes", object);
+            }
+
+            // Get the data objects within the collection
+            query = fmt::format(
+                "select COLL_NAME, DATA_NAME, DATA_OWNER_NAME, DATA_SIZE, DATA_MODIFY_TIME where COLL_NAME = '{}'",
+                full_path.parent_path().c_str());
+            std::cout << query << std::endl;
+            for (auto&& row : irods::query<RcComm>(rcComm_t_ptr.get(), query)) {
+                found_objects = true;
+                ptree object;
+                std::string key = (row[0].size() > base_length ? row[0].substr(base_length) : "") + "/" + row[1];
+                if (key.starts_with("/")) {
+                    key = key.substr(1);
+                }
+                object.put("Key", key);
+                object.put("Etag", row[0] + row[1]);
+                object.put("Owner", row[2]);
+                object.put("Size", atoi(row[3].c_str()));
+                try {
+                    std::time_t modified_epoch_time = boost::lexical_cast<std::time_t>(row[4]);
+                    std::string modified_time_str = irods::s3::api::common_routines::convert_time_t_to_str(modified_epoch_time, date_format);
+                    object.put("LastModified", modified_time_str);
+                } catch ( const boost::bad_lexical_cast& ) {
+                    // do nothing - don't add LastModified tag
+                }
+                document.add_child("ListBucketResult.Contents", object);
+            }
+        } else {
+
+            // Path does not end in a slash.  This is a query for collections and data objects
+            // with a trailing wildcard.
+
+            // First get collections
+            query = fmt::format(
+                "select COLL_NAME where COLL_NAME like '{}%' and COLL_NAME not like '{}%/%'",
+                full_path.c_str(),
+                full_path.c_str());
+            std::cout << query << std::endl;
+            for (auto&& row : irods::query<RcComm>(rcComm_t_ptr.get(), query)) {
+                found_objects = true;
+                ptree object;
+                std::string key = (row[0].size() > base_length ? row[0].substr(base_length) : "");
+                if (key.starts_with("/")) {
+                    key = key.substr(1);
+                }
+                key += "/";
+                object.put("Prefix", key);
+                document.add_child("ListBucketResult.CommonPrefixes", object);
+            }
+
+            // Now get data objects 
+            query = fmt::format(
+                "select COLL_NAME, DATA_NAME, DATA_OWNER_NAME, DATA_SIZE, DATA_MODIFY_TIME where COLL_NAME = '{}'"
+                " and DATA_NAME like '{}%'",
+                full_path.parent_path().c_str(),
+                full_path.object_name().c_str());
+            std::cout << query << std::endl;
+            for (auto&& row : irods::query<RcComm>(rcComm_t_ptr.get(), query)) {
+                found_objects = true;
+                ptree object;
+                std::string key = (row[0].size() > base_length ? row[0].substr(base_length) : "") + "/" + row[1];
+                if (key.starts_with("/")) {
+                    key = key.substr(1);
+                }
+                object.put("Key", key);
+                object.put("Etag", row[0] + row[1]);
+                object.put("Owner", row[2]);
+                object.put("Size", atoi(row[3].c_str()));
+                try {
+                    std::time_t modified_epoch_time = boost::lexical_cast<std::time_t>(row[4]);
+                    std::string modified_time_str = irods::s3::api::common_routines::convert_time_t_to_str(modified_epoch_time, date_format);
+                    object.put("LastModified", modified_time_str);
+                } catch ( const boost::bad_lexical_cast& ) {
+                    // do nothing - don't add LastModified tag
+                }
+                document.add_child("ListBucketResult.Contents", object);
+            }
+
+        }
+
+    } else {
+        
+        // No delimiter in request.  When there is no delimiter provided, for listing purposes AWS simply searches for all
+        // objects with the given prefix.  To make this behave similarly in iRODS, we need to perform two searches:
+        //
+        // 1.  Look for objects with COLL_NAME like <prefix>%
+        // 2.  Look for objects with COLL_NAME = <parent> and DATA_NAME like <object>% 
+
+        // look for objects with COLL_NAME like <prefix>% 
+        query = fmt::format(
+            "select COLL_NAME, DATA_NAME, DATA_OWNER_NAME, DATA_SIZE, DATA_MODIFY_TIME where COLL_NAME like '{}%'",
+            full_path.c_str());
+        std::cout << query << std::endl;
+        for (auto&& row : irods::query<RcComm>(rcComm_t_ptr.get(), query)) {
+            found_objects = true;
+            ptree object;
+            std::string key = (row[0].size() > base_length ? row[0].substr(base_length) : "") + "/" + row[1];
+            if (key.starts_with("/")) {
+                key = key.substr(1);
+            }
+            object.put("Key", key);
+            object.put("Etag", row[0] + row[1]);
+            object.put("Owner", row[2]);
+            object.put("Size", atoi(row[3].c_str()));
+            try {
+                std::time_t modified_epoch_time = boost::lexical_cast<std::time_t>(row[4]);
+                std::string modified_time_str = irods::s3::api::common_routines::convert_time_t_to_str(modified_epoch_time, date_format);
+                object.put("LastModified", modified_time_str);
+            } catch ( const boost::bad_lexical_cast& ) {
+                // do nothing - don't add LastModified tag
+            }
+            document.add_child("ListBucketResult.Contents", object);
+        }
+
+        // look for objects with COLL_NAME = <parent> and DATA_NAME like <object>% 
+        query = fmt::format(
+            "select COLL_NAME, DATA_NAME, DATA_OWNER_NAME, DATA_SIZE, DATA_MODIFY_TIME where COLL_NAME = '{}'"
+            " and DATA_NAME like '{}%'",
+            full_path.parent_path().c_str(),
+            full_path.object_name().c_str());
+        std::cout << query << std::endl;
+        for (auto&& row : irods::query<RcComm>(rcComm_t_ptr.get(), query)) {
+            found_objects = true;
+            ptree object;
+            std::string key = (row[0].size() > base_length ? row[0].substr(base_length) : "") + "/" + row[1];
+            if (key.starts_with("/")) {
+                key = key.substr(1);
+            }
+            object.put("Key", key);
+            object.put("Etag", row[0] + row[1]);
+            object.put("Owner", row[2]);
+            object.put("Size", atoi(row[3].c_str()));
+            try {
+                std::time_t modified_epoch_time = boost::lexical_cast<std::time_t>(row[4]);
+                std::string modified_time_str = irods::s3::api::common_routines::convert_time_t_to_str(modified_epoch_time, date_format);
+                object.put("LastModified", modified_time_str);
+            } catch ( const boost::bad_lexical_cast& ) {
+                // do nothing - don't add LastModified tag
+            }
+            document.add_child("ListBucketResult.Contents", object);
+        }
     }
 
-    if (found_objects) {
-        std::stringstream s;
-        boost::property_tree::xml_parser::xml_writer_settings<std::string> settings;
-        settings.indent_char = ' ';
-        settings.indent_count = 4;
-        std::cout << "Found objects" << std::endl;
-        boost::property_tree::write_xml(s, document, settings);
-        beast::http::response<beast::http::string_body> response;
-        response.body() = s.str();
-        std::cout << s.str();
 
-        beast::http::write(socket, response);
-    }
-    else {
-        std::cout << "Couldn't find anything" << std::endl;
-        beast::http::response<beast::http::empty_body> response;
-        response.result(beast::http::status::not_found);
-        beast::http::write(socket, response);
-    }
+    std::stringstream s;
+    boost::property_tree::xml_parser::xml_writer_settings<std::string> settings;
+    settings.indent_char = ' ';
+    settings.indent_count = 4;
+    boost::property_tree::write_xml(s, document, settings);
+    beast::http::response<beast::http::string_body> response;
+    response.body() = s.str();
+    std::cout << s.str();
+
+    beast::http::write(socket, response);
     co_return;
 }

--- a/src/s3/putobject.cpp
+++ b/src/s3/putobject.cpp
@@ -3,6 +3,7 @@
 
 #include "../authentication.hpp"
 #include "../bucket.hpp"
+#include "../configuration.hpp"
 
 #include <boost/beast/core/error.hpp>
 

--- a/src/s3/putobject.cpp
+++ b/src/s3/putobject.cpp
@@ -84,7 +84,7 @@ asio::awaitable<void> irods::s3::actions::handle_putobject(
         response.set("Etag", path.c_str());
         response.set("Connection", "close");
 
-        while (!parser.is_done() || !parser.get().body().more) {
+        while (!parser.is_done()) {
             parser.get().body().data = buf;
             parser.get().body().size = sizeof(buf);
             //            auto read = co_await beast::http::async_read_some(socket, buffer, parser,
@@ -92,8 +92,6 @@ asio::awaitable<void> irods::s3::actions::handle_putobject(
             auto read = beast::http::read_some(socket, buffer, parser);
             size_t read_bytes = sizeof(buf) - parser.get().body().size;
 
-            std::cout << "Read " << read_bytes << std::endl;
-            //            std::cout.write((char*) buf, read_bytes);
             try {
                 d.write((char*) buf, read_bytes);
             }

--- a/src/s3/putobject.cpp
+++ b/src/s3/putobject.cpp
@@ -79,7 +79,7 @@ asio::awaitable<void> irods::s3::actions::handle_putobject(
             co_return;
         }
 
-        uint64_t read_buffer_size = irods::s3::get_read_buffer_size_in_bytes();
+        uint64_t read_buffer_size = irods::s3::get_put_object_buffer_size_in_bytes();
         std::cout << "read buffer size = " << read_buffer_size << std::endl;
         std::vector<char> buf_vector(read_buffer_size);
         parser.get().body().data = buf_vector.data();

--- a/src/s3/putobject.cpp
+++ b/src/s3/putobject.cpp
@@ -69,6 +69,14 @@ asio::awaitable<void> irods::s3::actions::handle_putobject(
         irods::experimental::io::odstream d{
             xtrans, path, irods::experimental::io::root_resource_name{irods::s3::get_resource()}, std::ios_base::out};
 
+        if (!d.is_open()) {
+            beast::http::response<beast::http::empty_body> response;
+            response.result(beast::http::status::internal_server_error);
+            std::cerr << "Failed to open dstream" << std::endl;
+            beast::http::write(socket, response);
+            co_return;
+        }
+
         char buf[4096];
         parser.get().body().data = buf;
         parser.get().body().size = sizeof(buf);

--- a/src/s3/s3_api.hpp
+++ b/src/s3/s3_api.hpp
@@ -18,6 +18,11 @@ namespace irods::s3::actions
         static_buffer_request_parser& parser,
         const boost::urls::url_view& url);
 
+    boost::asio::awaitable<void> handle_listbuckets(
+        boost::asio::ip::tcp::socket& socket,
+        static_buffer_request_parser& parser,
+        const boost::urls::url_view& url);
+
     boost::asio::awaitable<void> handle_getobject(
         boost::asio::ip::tcp::socket& socket,
         static_buffer_request_parser& parser,


### PR DESCRIPTION
* Added ModifyTime for list object.
* Make ListObjects work as AWS does.
* Undo multiple url encodes which were causing signature failures.
* On upload, checked for odstream open errors and returned INTERNAL_SERVER_ERROR if open failed.
* Removed compiler warnings for uncompleted methods without return codes. Returned false with a TODO instead.
* Fixed HeadObject by reading data object size and modify time.
* Fixed large file upload failures by adding body_limit().
* Added config params for read/write buffer sizes.
* Added support for the range header on GetObject.