### PR TITLE
Allow server to run against iRODS 4.2 servers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 set(IRODS_CLIENT_VERSION "0.1.0")
-set(IRODS_PACKAGE_REVISION "1")
+set(IRODS_PACKAGE_REVISION "0")
 
 #
 # Build Configuration

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,9 +61,18 @@ RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - 
     wget -qO - https://core-dev.irods.org/irods-core-dev-signing-key.asc | apt-key add - && \
     echo "deb [arch=amd64] https://core-dev.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods-core-dev.list
 
+ARG irods_version=4.3.1-0~focal
 RUN apt-get update && \
     apt-get install -y \
-        'irods-externals*' \
+        irods-externals-clang13.0.0-0 \
+        irods-externals-cmake3.21.4-0 \
+        irods-externals-fmt8.1.1-0 \
+        irods-externals-json3.10.4-0 \
+        irods-externals-nanodbc2.13.0-1 \
+        irods-externals-spdlog1.9.2-1 \
+        irods-dev=${irods_version} \
+        irods-runtime=${irods_version} \
+        irods-icommands=${irods_version} \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
@@ -80,20 +89,15 @@ ENV PATH=${cmake_path}:$PATH
 
 COPY scripts scripts
 
-COPY ./irods-dev_4.3.0-1~focal_amd64.deb ./irods-runtime_4.3.0-1~focal_amd64.deb /irods43X_packages/
-
-RUN bash scripts/get_build_deps.sh
-
 RUN mkdir irods_s3_bridge
 
 COPY . irods_s3_bridge
 
 RUN bash scripts/build_bridge.sh
 
-RUN ls -l /irods_s3_bridge/build && dpkg -i /irods_s3_bridge/build/irods-experimental-client-s3-api_0.1.0-1~focal_amd64.deb
+RUN ls -l /irods_s3_bridge/build && dpkg -i /irods_s3_bridge/build/irods-experimental-client-s3-api_0.1.0-0~focal_amd64.deb
 
-RUN chmod +x scripts/run_bridge.sh
-
-RUN mkdir -p /root/.irods
+RUN chmod +x scripts/run_bridge.sh && \
+    mkdir -p /root/.irods
 
 ENTRYPOINT [ "scripts/run_bridge.sh" ]

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The following code block shows the structure of the configuration file and provi
 
         // The credentials for the rodsadmin user that will act as a proxy
         // for all authenticated users.
-        "rodsadmin": {
+        "proxy_admin_account": {
             "username": "<string>",
             "password": "<string>"
         }

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Initial effort includes:
   - CreateMultipartUpload
   - [x] DeleteObject
   - DeleteObjects
-  - [x] GetObject
   - [x] GetBucketLocation
+  - [x] GetObject
   - GetObjectAcl ?
   - [x] GetObjectLockConfiguration
   - GetObjectTagging ?
@@ -202,6 +202,10 @@ You can follow the log file by running the following:
 ```bash
 docker logs -f irods_s3_api
 ```
+
+This application can also run against iRODS 4.2.11 and 4.2.12. No adjustments to your configuration file are required.
+
+**IMPORTANT: This project requires the iRODS 4.3.1 runtime and therefore cannot be run on the same machine hosting an iRODS 4.2 server.**
 
 ## Connecting with Botocore
 

--- a/config.json.template
+++ b/config.json.template
@@ -36,7 +36,7 @@
 
         "zone": "tempZone",
 
-        "rodsadmin": {
+        "proxy_admin_account": {
             "username": "rods",
             "password": "rods"
         }

--- a/scripts/get_build_deps.sh
+++ b/scripts/get_build_deps.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# Add the package sources.
-sudo apt-get update
-sudo apt install -y irods-dev irods-externals-\* irods-icommands
-
-# Install the packages.
-dpkg -i irods43X_packages/irods-dev_4.3.0-1~focal_amd64.deb
-dpkg -i irods43X_packages/irods-runtime_4.3.0-1~focal_amd64.deb

--- a/src/authentication.hpp
+++ b/src/authentication.hpp
@@ -10,12 +10,15 @@
 
 namespace irods::s3::authentication
 {
-    /// Authenticates an iRODS connection and switch to that user.
+    /// Resolves the hashed signature to an iRODS username.
+    ///
     /// \param conn The connection to the iRODS server.
     /// \param request The request.
     /// \param url The url
-    /// \returns If the user was successfully authenticated.
-    bool authenticates(rcComm_t& conn, const static_buffer_request_parser& request, const boost::urls::url_view& url);
+    ///
+    /// \returns An iRODS username if the signature is correct, else an empty std::optional.
+    std::optional<std::string> authenticates(rcComm_t& conn, const static_buffer_request_parser& request, const boost::urls::url_view& url);
+
     bool user_exists(rcComm_t& connection, const std::string_view username);
     bool delete_user(rcComm_t& connection, const std::string_view username);
     bool create_user(rcComm_t& connection, const std::string_view username, const std::string_view secret_key);

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -4,7 +4,7 @@
 #include <irods/rcConnect.h>
 #include <optional>
 
-std::unique_ptr<rcComm_t, irods::s3::__detail::rcComm_Deleter> irods::s3::get_connection()
+std::unique_ptr<rcComm_t, irods::s3::__detail::rcComm_Deleter> irods::s3::get_connection(const std::optional<std::string>& _client_username)
 {
     std::unique_ptr<rcComm_t, irods::s3::__detail::rcComm_Deleter> result = nullptr;
     // For some reason it isn't working with the assignment operator
@@ -18,7 +18,13 @@ std::unique_ptr<rcComm_t, irods::s3::__detail::rcComm_Deleter> irods::s3::get_co
     const auto& password = get_config().at(json_ptr{"/irods_client/rodsadmin/password"}).get_ref<const std::string&>();
 
     rErrMsg_t err{};
-    result.reset(rcConnect(host.c_str(), port, username.c_str(), zone.c_str(), 0, &err));
+
+    if (_client_username) {
+        result.reset(_rcConnect(host.c_str(), port, username.c_str(), zone.c_str(), _client_username->c_str(), zone.c_str(), &err, 0, 0));
+    }
+    else {
+        result.reset(rcConnect(host.c_str(), port, username.c_str(), zone.c_str(), 0, &err));
+    }
 
     if (nullptr == result || err.status) {
         std::cerr << err.msg << std::endl;

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -14,8 +14,8 @@ std::unique_ptr<rcComm_t, irods::s3::__detail::rcComm_Deleter> irods::s3::get_co
     const auto& host = get_config().at(json_ptr{"/irods_client/host"}).get_ref<const std::string&>();
     const auto  port = get_config().at(json_ptr{"/irods_client/port"}).get<int>();
     const auto& zone = get_config().at(json_ptr{"/irods_client/zone"}).get_ref<const std::string&>();
-    const auto& username = get_config().at(json_ptr{"/irods_client/rodsadmin/username"}).get_ref<const std::string&>();
-    const auto& password = get_config().at(json_ptr{"/irods_client/rodsadmin/password"}).get_ref<const std::string&>();
+    const auto& username = get_config().at(json_ptr{"/irods_client/proxy_admin_account/username"}).get_ref<const std::string&>();
+    const auto& password = get_config().at(json_ptr{"/irods_client/proxy_admin_account/password"}).get_ref<const std::string&>();
 
     rErrMsg_t err{};
 

--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -7,6 +7,8 @@
 
 #include <iostream>
 #include <memory>
+#include <optional>
+#include <string>
 
 namespace irods::s3
 {
@@ -27,9 +29,6 @@ namespace irods::s3
 
     using connection_handle = std::unique_ptr<rcComm_t, __detail::rcComm_Deleter>;
 
-    std::unique_ptr<rcComm_t, __detail::rcComm_Deleter> get_connection();
-
-
-
+    std::unique_ptr<rcComm_t, __detail::rcComm_Deleter> get_connection(const std::optional<std::string>& _client_username = std::nullopt);
 } //namespace irods::s3
 #endif // IRODS_S3_API_CONNECTION_HPP

--- a/src/s3/deleteobject.cpp
+++ b/src/s3/deleteobject.cpp
@@ -42,13 +42,21 @@ asio::awaitable<void> irods::s3::actions::handle_deleteobject(
 {
     auto thing = irods::s3::get_connection();
     auto url_and_stuff = boost::urls::url_view(parser.get().base().target());
+
     // Permission verification stuff should go roughly here.
-    if (!irods::s3::authentication::authenticates(*thing, parser, url)) {
+
+    auto irods_username = irods::s3::authentication::authenticates(*thing, parser, url);
+    if (!irods_username) {
         beast::http::response<beast::http::empty_body> response;
         response.result(beast::http::status::forbidden);
         beast::http::write(socket, response);
         co_return;
     }
+
+    // Reconnect to the iRODS server as the target user.
+    // The rodsadmin account from the config file will act as the proxy for the user.
+    thing = irods::s3::get_connection(irods_username);
+
     fs::path path;
     if (auto bucket = irods::s3::resolve_bucket(*thing, url.segments()); bucket.has_value()) {
         path = bucket.value();

--- a/src/s3/getobject.cpp
+++ b/src/s3/getobject.cpp
@@ -46,13 +46,20 @@ asio::awaitable<void> irods::s3::actions::handle_getobject(
     auto thing = irods::s3::get_connection();
 
     // Permission verification stuff should go roughly here.
-    if (!irods::s3::authentication::authenticates(*thing, parser, url)) {
+
+    auto irods_username = irods::s3::authentication::authenticates(*thing, parser, url);
+    if (!irods_username) {
         std::cout<<"Authentication failed"<<std::endl;
         beast::http::response<beast::http::empty_body> response;
         response.result(beast::http::status::forbidden);
         beast::http::write(socket, response);
         co_return;
     }
+
+    // Reconnect to the iRODS server as the target user.
+    // The rodsadmin account from the config file will act as the proxy for the user.
+    thing = irods::s3::get_connection(irods_username);
+
     fs::path path;
     if (auto bucket = irods::s3::resolve_bucket(*thing, url.segments()); bucket.has_value()) {
         path = bucket.value();


### PR DESCRIPTION
This PR was manually tested against 4.2.12.

The tests included the following things using boto:
- ListObjectV2
- HeadObject
- PutObject
- GetObject

The tests were NOT extensive, but I don't suspect anything is broken by this PR since the connection logic is the only thing that was touched.