### PR TITLE
[57] Changed s3_region config to region

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ The following code block shows the structure of the configuration file and provi
         "get_object_buffer_size_in_bytes": 8192,
 
         // The region returned in the GetBucketLocation API call.  The default is us-east-1.
-        "s3_region": "us-east-1"
+        "region": "us-east-1"
     },
 
     // Defines how the S3 API server connects to an iRODS server.

--- a/config.json.template
+++ b/config.json.template
@@ -27,7 +27,7 @@
 
         "put_object_buffer_size_in_bytes": 8192,
         "get_object_buffer_size_in_bytes": 8192,
-        "s3_region": "us-east-1"
+        "region": "us-east-1"
     },
 
     "irods_client": {

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -44,7 +44,7 @@ std::string irods::s3::get_s3_region()
 {
     if (!s3_region.has_value()) {
         s3_region = g_config.value(
-                nlohmann::json::json_pointer{"/s3_server/s3_region"}, "us-east-1");
+                nlohmann::json::json_pointer{"/s3_server/region"}, "us-east-1");
     }
     return s3_region.value();
 }


### PR DESCRIPTION
This is just a configuration parameter change.

Note that the code still has variables/methods that refer to s3_region.  I think it remains more clear there but the json configuration is now just region.

Tests passed.