### PR TITLE
[#80] CMake: Fix a typo in the installation destination

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ install(
   ${IRODS_S3_API_BINARY_NAME}
   ${IRODS_S3_API_AUTH_RESOLVER_NAME}
   ${IRODS_S3_API_BUCKET_RESOLVER_PLUGIN_NAME}
-  DESTINATION "${LIBDIR}/irods/clients/s3_api")
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/irods/clients/s3_api")
 
 #
 # Packaging Configuration


### PR DESCRIPTION
My last PR had a typo in a variable name that we missed. This PR fixes it.